### PR TITLE
[setup.py] "C++" changed to "c++"

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -111,7 +111,7 @@ ext_modules = [
             numpy_include,
             "FLED"
         ],
-        language = "C++",
+        language = "c++",
         extra_compile_args = extra_compile_args,
         libraries = libraries,
         library_dirs = [str(opencv_lib_dirs)]


### PR DESCRIPTION
Cython updated version changes.

New cython version does not support "C++" string. It has been changed to "c++".